### PR TITLE
hotfix: ensure navbar is above dashboard by adjusting layout and styles

### DIFF
--- a/src/microfrontend-layout.html
+++ b/src/microfrontend-layout.html
@@ -6,21 +6,26 @@
 
   -->
 
-  <!-- Example layouts you might find helpful:
+  <style>
+    .navbar-container {
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 1000; /* Ensure navbar is on top */
+    }
 
-  <nav>
-    <application name="@org/navbar"></application>
-  </nav>
-  <route path="settings">
-    <application name="@org/settings"></application>
-  </route>
-
-  -->
+    .dashboard-container {
+      margin-top: 60px; /* Adjust based on the navbar height */
+      z-index: 500; /* Ensure dashboard is behind the navbar */
+    }
+  </style>
 
   <main>
-    <route default>
+    <div class="navbar-container">
       <application name="@microfront/microfront-navbar"></application>
+    </div>
+    <div class="dashboard-container">
       <application name="@microfront/microfront-dashboard"></application>
-    </route>
+    </div>
   </main>
 </single-spa-router>


### PR DESCRIPTION
- [x]  Ensure navbar is above dashboard by adjusting layout and styles.

![image](https://github.com/Duvanmontes/MicroFrontend/assets/72611092/9c540d87-2db2-4c4a-9212-89f41af56791)
